### PR TITLE
Add php7.2-gmp for php-oauth2 decryption module

### DIFF
--- a/ubuntu18/php7.2/Dockerfile
+++ b/ubuntu18/php7.2/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update --fix-missing && apt-get install --no-install-recommends -y \
     php7.2-zip \
     php7.2-xml \
     php7.2-xdebug \
+    php7.2-gmp \
     apache2 \
     libapache2-mod-php7.2 \
     git \


### PR DESCRIPTION
php-oauth2의 web-token decryption 모듈을 위해서는 php7.2-gmp 를 os 내에 설치해줘야 해서 해당 의존성을 도커파일에 추가합니다. 

의존성 링크 : https://web-token.spomky-labs.com/#prerequisites
관련 아사나 링크 : https://app.asana.com/0/547078815478895/1144698044360185/f